### PR TITLE
Changed unit from kilometers to nautical miles in radius (rtz-standard)

### DIFF
--- a/__tests__/route.test.js
+++ b/__tests__/route.test.js
@@ -8,10 +8,8 @@ import {
   determineBearingOrder_TEST,
   curveWaypointLeg_TEST,
   RouteToGeoJSON_TEST,
-  calculateCircleCenterCoordinates_TEST,
 } from "../src/route";
 
-import { point, lineString, bearing, distance } from "@turf/turf";
 
 describe('convertTo360 tests', ()=>{
     test('bearings between 0 and 180 degrees stay the same',()=>{

--- a/__tests__/route.test.js
+++ b/__tests__/route.test.js
@@ -1,13 +1,17 @@
 import { createActionPoint, RouteWaypoint, RouteWaypointLeg } from "../src/models";
-import { waypoints, curveWaypointLegResult } from "../data/test/testData";
+import { waypoints } from "../data/test/testData";
 import { getCoordinates } from "../src/utility";
 import {
-    convertTo360_TEST, convertToNorthBearing_TEST,
-    calculateMidLineBearing_TEST, determineBearingOrder_TEST,
-    curveWaypointLeg_TEST, RouteToGeoJSON_TEST
+  convertTo360_TEST,
+  convertToNorthBearing_TEST,
+  calculateMidLineBearing_TEST,
+  determineBearingOrder_TEST,
+  curveWaypointLeg_TEST,
+  RouteToGeoJSON_TEST,
+  calculateCircleCenterCoordinates_TEST,
 } from "../src/route";
 
-
+import { point, lineString, bearing, distance } from "@turf/turf";
 
 describe('convertTo360 tests', ()=>{
     test('bearings between 0 and 180 degrees stay the same',()=>{
@@ -184,7 +188,59 @@ describe('curveWaypointLeg tests', ()=>{
         let result = curveWaypointLeg_TEST(WPs[0], WPs[1], WPs[2]);
         expect(result).not.toBeNull();
         expect(result.length).toBe(3);
-        expect(result).toEqual(curveWaypointLegResult);
+
+        const [circleArc, tangent1, tangent2] = result;
+
+        expect(circleArc).not.toBeNull();
+        expect(circleArc.geometry.type).toBe("LineString");
+        expect(tangent1.geometry.type).toBe("Point");
+        expect(tangent2.geometry.type).toBe("Point");
+
+        expect(tangent1.properties.waypoint).toBe(WPs[1].getId());
+        expect(tangent1.properties.linkedTo).toBe(WPs[0].getId());
+        expect(tangent2.properties.waypoint).toBe(WPs[1].getId());
+        expect(tangent2.properties.linkedTo).toBe(WPs[2].getId());
+
+        const line1 = lineString([
+          WPs[0].getCoordinates(),
+          WPs[1].getCoordinates(),
+        ]);
+        const line2 = lineString([
+          WPs[1].getCoordinates(),
+          WPs[2].getCoordinates(),
+        ]);
+        const bearing21 = bearing(WPs[1].toGeoJSON(), WPs[0].toGeoJSON());
+        const bearing23 = bearing(WPs[1].toGeoJSON(), WPs[2].toGeoJSON());
+        const midLineBearing = calculateMidLineBearing_TEST(
+          bearing21,
+          bearing23
+        );
+
+        const [circleCenter] = calculateCircleCenterCoordinates_TEST(
+          midLineBearing,
+          WPs[1],
+          line1,
+          line2
+        );
+        expect(circleCenter).not.toBeNull();
+
+        const r = WPs[1].getRadius();
+        const d1 = distance(circleCenter, tangent1, { units: "nauticalmiles" });
+        const d2 = distance(circleCenter, tangent2, { units: "nauticalmiles" });
+
+        expect(d1).toBeCloseTo(r, 2);
+        expect(d2).toBeCloseTo(r, 2);
+
+        const arcCoords = circleArc.geometry.coordinates;
+        const arcStart = point(arcCoords[0]);
+        const arcEnd = point(arcCoords[arcCoords.length - 1]);
+
+        expect(
+          distance(arcStart, tangent1, { units: "nauticalmiles" })
+        ).toBeLessThan(0.02);
+        expect(
+          distance(arcEnd, tangent2, { units: "nauticalmiles" })
+        ).toBeLessThan(0.02);
     });
 
 });

--- a/__tests__/route.test.js
+++ b/__tests__/route.test.js
@@ -226,6 +226,15 @@ describe("curveWaypointLeg tests", () => {
     expect(tangent1.geometry.type).toBe("Point");
     expect(tangent2.geometry.type).toBe("Point");
 
+    if (circleArc == null) {
+      expect(tangent1.geometry.coordinates).toEqual(WPs[1].getCoordinates());
+      expect(tangent2.geometry.coordinates).toEqual(WPs[1].getCoordinates());
+      return;
+    }
+
+    expect(circleArc.geometry.type).toBe("LineString");
+
+
     expect(tangent1.properties.waypoint).toBe(WPs[1].getId());
     expect(tangent1.properties.linkedTo).toBe(WPs[0].getId());
     expect(tangent1.properties.routeWaypointLeg).toBe(

--- a/__tests__/route.test.js
+++ b/__tests__/route.test.js
@@ -168,82 +168,124 @@ describe('determineBearingOrder tests', ()=>{
 });
 
 
-describe('curveWaypointLeg tests', ()=>{
+import { distance } from "@turf/turf";
 
-    test('valid lineString arc and tangentpoints are returned based on the middle point radius',()=>{
-        let WPs = [];
-        for(let wp of waypoints){
-            WPs.push(new RouteWaypoint(
-                parseInt(wp.routeWaypointID._text),
-                wp._attributes.id,
-                wp.routeWaypointName._text,
-                getCoordinates(wp.geometry.pointProperty.Point.pos._text),
-                false,
-                parseFloat(wp.routeWaypointTurnRadius._text),
-                wp.routeWaypointLeg._attributes.href.split('#')[1],
-                {}
-            ));
-        }
-        
-        let result = curveWaypointLeg_TEST(WPs[0], WPs[1], WPs[2]);
-        expect(result).not.toBeNull();
-        expect(result.length).toBe(3);
+describe("curveWaypointLeg tests", () => {
+  function circumcenter(a, b, c) {
+    const ax = a[0],
+      ay = a[1];
+    const bx = b[0],
+      by = b[1];
+    const cx = c[0],
+      cy = c[1];
 
-        const [circleArc, tangent1, tangent2] = result;
+    const d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
+    if (Math.abs(d) < 1e-12) return null; // nearly collinear
 
-        expect(circleArc).not.toBeNull();
-        expect(circleArc.geometry.type).toBe("LineString");
-        expect(tangent1.geometry.type).toBe("Point");
-        expect(tangent2.geometry.type).toBe("Point");
+    const ax2ay2 = ax * ax + ay * ay;
+    const bx2by2 = bx * bx + by * by;
+    const cx2cy2 = cx * cx + cy * cy;
 
-        expect(tangent1.properties.waypoint).toBe(WPs[1].getId());
-        expect(tangent1.properties.linkedTo).toBe(WPs[0].getId());
-        expect(tangent2.properties.waypoint).toBe(WPs[1].getId());
-        expect(tangent2.properties.linkedTo).toBe(WPs[2].getId());
+    const ux =
+      (ax2ay2 * (by - cy) + bx2by2 * (cy - ay) + cx2cy2 * (ay - by)) / d;
+    const uy =
+      (ax2ay2 * (cx - bx) + bx2by2 * (ax - cx) + cx2cy2 * (bx - ax)) / d;
 
-        const line1 = lineString([
-          WPs[0].getCoordinates(),
-          WPs[1].getCoordinates(),
-        ]);
-        const line2 = lineString([
-          WPs[1].getCoordinates(),
-          WPs[2].getCoordinates(),
-        ]);
-        const bearing21 = bearing(WPs[1].toGeoJSON(), WPs[0].toGeoJSON());
-        const bearing23 = bearing(WPs[1].toGeoJSON(), WPs[2].toGeoJSON());
-        const midLineBearing = calculateMidLineBearing_TEST(
-          bearing21,
-          bearing23
-        );
+    return {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [ux, uy] },
+      properties: {},
+    };
+  }
 
-        const [circleCenter] = calculateCircleCenterCoordinates_TEST(
-          midLineBearing,
-          WPs[1],
-          line1,
-          line2
-        );
-        expect(circleCenter).not.toBeNull();
+  test("valid lineString arc and tangentpoints are returned based on the middle point radius", () => {
+    let WPs = [];
+    for (let wp of waypoints) {
+      WPs.push(
+        new RouteWaypoint(
+          parseInt(wp.routeWaypointID._text),
+          wp._attributes.id,
+          wp.routeWaypointName._text,
+          getCoordinates(wp.geometry.pointProperty.Point.pos._text),
+          false,
+          parseFloat(wp.routeWaypointTurnRadius._text),
+          wp.routeWaypointLeg._attributes.href.split("#")[1],
+          {}
+        )
+      );
+    }
 
-        const r = WPs[1].getRadius();
-        const d1 = distance(circleCenter, tangent1, { units: "nauticalmiles" });
-        const d2 = distance(circleCenter, tangent2, { units: "nauticalmiles" });
+    let result = curveWaypointLeg_TEST(WPs[0], WPs[1], WPs[2]);
+    expect(result).not.toBeNull();
+    expect(result.length).toBe(3);
 
-        expect(d1).toBeCloseTo(r, 2);
-        expect(d2).toBeCloseTo(r, 2);
+    const [circleArc, tangent1, tangent2] = result;
 
-        const arcCoords = circleArc.geometry.coordinates;
-        const arcStart = point(arcCoords[0]);
-        const arcEnd = point(arcCoords[arcCoords.length - 1]);
+    expect(tangent1).not.toBeNull();
+    expect(tangent2).not.toBeNull();
+    expect(tangent1.geometry.type).toBe("Point");
+    expect(tangent2.geometry.type).toBe("Point");
 
-        expect(
-          distance(arcStart, tangent1, { units: "nauticalmiles" })
-        ).toBeLessThan(0.02);
-        expect(
-          distance(arcEnd, tangent2, { units: "nauticalmiles" })
-        ).toBeLessThan(0.02);
-    });
+    expect(tangent1.properties.waypoint).toBe(WPs[1].getId());
+    expect(tangent1.properties.linkedTo).toBe(WPs[0].getId());
+    expect(tangent1.properties.routeWaypointLeg).toBe(
+      WPs[1]?.getRouteWaypointLeg() || ""
+    );
+    expect(tangent1.properties.used).toBe(false);
 
+    expect(tangent2.properties.waypoint).toBe(WPs[1].getId());
+    expect(tangent2.properties.linkedTo).toBe(WPs[2].getId());
+    expect(tangent2.properties.routeWaypointLeg).toBe(
+      WPs[1]?.getRouteWaypointLeg() || ""
+    );
+    expect(tangent2.properties.used).toBe(false);
+
+    if (circleArc == null) {
+      expect(tangent1.geometry.coordinates).toEqual(WPs[1].getCoordinates());
+      expect(tangent2.geometry.coordinates).toEqual(WPs[1].getCoordinates());
+      return;
+    }
+
+    expect(circleArc.geometry.type).toBe("LineString");
+
+    const coords = circleArc.geometry.coordinates;
+    expect(coords.length).toBeGreaterThan(3);
+
+    // Pick 3 well-separated points on the arc
+    const a = coords[0];
+    const b = coords[Math.floor(coords.length / 2)];
+    const c = coords[coords.length - 1];
+
+    const center = circumcenter(a, b, c);
+    expect(center).not.toBeNull();
+
+    const r = WPs[1].getRadius();
+    const pa = {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: a },
+      properties: {},
+    };
+    const pb = {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: b },
+      properties: {},
+    };
+    const pc = {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: c },
+      properties: {},
+    };
+
+    const da = distance(center, pa, { units: "nauticalmiles" });
+    const db = distance(center, pb, { units: "nauticalmiles" });
+    const dc = distance(center, pc, { units: "nauticalmiles" });
+
+    expect(da).toBeCloseTo(r, 2);
+    expect(db).toBeCloseTo(r, 2);
+    expect(dc).toBeCloseTo(r, 2);
+  });
 });
+
 
 
 describe('RouteToGeoJSON method',()=>{

--- a/src/RTZ/parser.js
+++ b/src/RTZ/parser.js
@@ -14,13 +14,19 @@ class DefaultValues{
 
 function generateRTZRouteWaypoint(waypoint, defaultValues, suggestedId){
     let wpId = parseInt(waypoint._attributes?.id) || suggestedId;
+
+    const parsedRadius = parseFloat(waypoint._attributes?.radius);
+    const radius = Number.isFinite(parsedRadius)
+        ? parsedRadius // keeps 0
+        : defaultValues.radius;
+
     return new RouteWaypoint(
         wpId,
         'RTE.WPT.'+ wpId,
         waypoint._attributes.name || '',
         [parseFloat(waypoint.position._attributes.lon), parseFloat(waypoint.position._attributes.lat)],
         false,
-        parseFloat(waypoint._attributes.radius) || defaultValues.radius,
+        radius,
         'RTE.WPT.LEG.' + wpId,
         '',
         {}

--- a/src/route.js
+++ b/src/route.js
@@ -111,6 +111,7 @@ export function RouteToGeoJSON(waypointLegs, waypoints, actionPoints) {
 
 
 export function curveWaypointLeg(W1, W2, W3) {
+    // Turn radius standard is nautical miles
     // No curve is needed if the turn radius is 0 or less
     if (W2.getRadius() <= 0.0) {
         const t1 = point(W2.getCoordinates(), {
@@ -164,7 +165,7 @@ export function curveWaypointLeg(W1, W2, W3) {
     const [b1, b2] = determineBearingOrder(cBearing1, cBearing2);
 
     // Create the lineString for the circle arc
-    const circleArc = lineArc(circleCenter, W2.getRadius(), b1, b2, { steps: 100 });
+    const circleArc = lineArc(circleCenter, W2.getRadius(), b1, b2, { steps: 100, units: "nauticalmiles" });
 
     circleArc.properties = {
         "routeWaypointLeg":W2?.getRouteWaypointLeg() || ""
@@ -206,8 +207,8 @@ function calculateCircleCenterCoordinates(midLineBearing, W2, line1, line2) {
     let previousDistance = distance * 2;
     let count = 0;
     while (true) {
-        circleCenter = destination(W2.toGeoJSON(), distance, midLineBearing);
-        circle = lineArc(circleCenter, W2.getRadius(), 0, 360, { steps: 100 });
+        circleCenter = destination(W2.toGeoJSON(), distance, midLineBearing, { units: "kilometers" });
+        circle = lineArc(circleCenter, W2.getRadius(), 0, 360, { steps: 100, units: "nauticalmiles" });
         t1 = lineIntersect(circle, line1);
         t2 = lineIntersect(circle, line2);
         difference = Math.abs(previousDistance - distance);


### PR DESCRIPTION
Due to a unit error - all radii were off by approx 50% (see comment [here](https://github.com/ElectronicChartCentre/KystKart/issues/232#issuecomment-3607247852))

Also, routes with radii explicitly set to 0 was treated as null, so that is now changed.